### PR TITLE
Fix HYCOM's README.md 

### DIFF
--- a/Fortran/HYCOM/README.md
+++ b/Fortran/HYCOM/README.md
@@ -10,7 +10,7 @@
 
 ```bash
 $ cd src
-$ bear
+$ bear -- make
 ```
 
 2. Analyze it with Codee: [HYCOM modernization guide](https://docs.codee.com/demos/fortran/modernization/hycom)


### PR DESCRIPTION
The compilation command on HYCOM's readme was incomplete. Just added the correct one.