### PR TITLE
Remove `?` character from the Makefiles for the Fortran codes

### DIFF
--- a/Fortran/Himeno/Makefile
+++ b/Fortran/Himeno/Makefile
@@ -1,4 +1,4 @@
-FC ?= gfortran
+FC = gfortran
 FFLAGS ?= -O3
 SRC = himeno.f90
 TARGET ?= himeno

--- a/Fortran/MATMUL/Makefile
+++ b/Fortran/MATMUL/Makefile
@@ -3,7 +3,7 @@ SOURCES = matmul.f90 time.f90
 FILE ?= main.f90
 TARGET ?= matmul
 FFLAGS = -O3
-FC ?= gfortran
+FC = gfortran
 
 default: run
 

--- a/Fortran/NUCCOR/Makefile
+++ b/Fortran/NUCCOR/Makefile
@@ -1,4 +1,4 @@
-FC ?= gfortran
+FC = gfortran
 FLAGS ?= -O3 -fopenmp
 objects = mtc_patch.o mtc.o mtc_openmp.o mtc_main.o
 


### PR DESCRIPTION

- The `?=` may cause the use of an alias instead of `gfortran` and that will cause trouble with `bear`. By default, not specifying the FC in the make invocation will set f77 as the fortran compiler.